### PR TITLE
Avoid UART6 Rx FIFO overrun issue by disabling DMA while in low-latency mode.

### DIFF
--- a/drivers/tty/serial/imx.c
+++ b/drivers/tty/serial/imx.c
@@ -1221,7 +1221,8 @@ static int imx_startup(struct uart_port *port)
 
 	/* Can we enable the DMA support? */
 	if (is_imx6q_uart(sport) && !uart_console(port)
-		&& !sport->dma_is_inited)
+		&& !sport->dma_is_inited
+		&& !sport->port.flags == UPF_LOW_LATENCY)
 		imx_uart_dma_init(sport);
 
 	if (sport->dma_is_inited) {


### PR DESCRIPTION
Based on:

http://forum.embeddedarm.com/showthread.php?1170-UART-Rx-Fifo-Overrun-Error
